### PR TITLE
Dependency Updates

### DIFF
--- a/.github/workflows/callUpdateTarget.yml
+++ b/.github/workflows/callUpdateTarget.yml
@@ -6,8 +6,6 @@ concurrency:
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 */2 * * *'
   push:
     branches:
       - master
@@ -17,7 +15,7 @@ on:
 
 jobs:
   update:
-    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/updateTarget.yml@master
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/updateTarget.yml@master
     with:
       author: Eclipse Releng Bot <releng-bot@eclipse.org>
       path: 'eclipse.platform.releng.prereqs.sdk'

--- a/.github/workflows/updateTarget.yml
+++ b/.github/workflows/updateTarget.yml
@@ -51,7 +51,7 @@ jobs:
         commit-message: Update target-platform with latest version
         branch: update_target
         title: Dependency Updates
-        body-path: ${{ inputs.path }} /target/targetUpdates.md
+        body-path: ${{ inputs.path }}/target/targetUpdates.md
         delete-branch: true
         draft: false
         token: ${{ secrets.token }}

--- a/.github/workflows/updateTarget.yml
+++ b/.github/workflows/updateTarget.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Update Target Platform
       working-directory: ${{ inputs.path }} 
       run: >-
-          mvn -ntp -f --non-recursive  
+          mvn -ntp --non-recursive
           tycho-version-bump:update-target@update-target
     - name: Create PR description file if missing
       if: ${{ hashFiles(format('{0}/target/targetUpdates.md', inputs.path)) == '' }}

--- a/.github/workflows/updateTarget.yml
+++ b/.github/workflows/updateTarget.yml
@@ -42,7 +42,8 @@ jobs:
     - name: Create PR description file if missing
       if: ${{ hashFiles(format('{0}/target/targetUpdates.md', inputs.path)) == '' }}
       working-directory: ${{ inputs.path }}
-      run: >-
+      run: |
+          mkdir -p target
           echo '## Everything is up to date' > target/targetUpdates.md
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5

--- a/.github/workflows/updateTarget.yml
+++ b/.github/workflows/updateTarget.yml
@@ -9,7 +9,7 @@ on:
         type: string
         default: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
       path:
-        description: Defines the committer / author that should be used for the commit
+        description: Defines the path where the target file to update is located
         required: true
         type: string
     secrets:
@@ -35,16 +35,22 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Update Target Platform
+      working-directory: ${{ inputs.path }} 
       run: >-
-          mvn -ntp -f ${{ inputs.path }} 
+          mvn -ntp -f --non-recursive  
           tycho-version-bump:update-target@update-target
+    - name: Create PR description file if missing
+      if: ${{ hashFiles(format('{0}/target/targetUpdates.md', inputs.path)) == '' }}
+      working-directory: ${{ inputs.path }}
+      run: >-
+          echo '## Everything is up to date' > target/targetUpdates.md
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
       with:
         commit-message: Update target-platform with latest version
         branch: update_target
         title: Dependency Updates
-        body: Please review the changes and merge if appropriate, or cherry pick individual updates.
+        body-path: ${{ inputs.path }} /target/targetUpdates.md
         delete-branch: true
         draft: false
         token: ${{ secrets.token }}

--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -70,15 +70,15 @@
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
-      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.7.0.v20250111-0100"/>
-      <unit id="org.eclipse.ecf.core.feature.source.feature.group" version="1.7.0.v20250111-0100"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.15.0.v20250115-0406"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.source.feature.group" version="3.15.0.v20250115-0406"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="2.1.0.v20250108-1923"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.source.feature.group" version="2.1.0.v20250108-1923"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="1.2.0.v20250122-1953"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.source.feature.group" version="1.2.0.v20250122-1953"/>
-      <repository location="https://download.eclipse.org/rt/ecf/3.15.5/site.p2/3.15.5.v20250124-1843"/>
+      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.6.2.v20240812-1535"/>
+      <unit id="org.eclipse.ecf.core.feature.source.feature.group" version="1.6.2.v20240812-1535"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.14.1900.v20240812-1535"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.source.feature.group" version="3.14.1900.v20240812-1535"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="2.0.200.v20240808-1900"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.source.feature.group" version="2.0.200.v20240808-1900"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="1.1.702.v20240808-1900"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.source.feature.group" version="1.1.702.v20240808-1900"/>
+      <repository location="https://download.eclipse.org/rt/ecf/3.15.2/site.p2/3.15.2.v20240821-2119"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
@@ -96,7 +96,7 @@
 			  <dependency>
 				  <groupId>com.google.code.gson</groupId>
 				  <artifactId>gson</artifactId>
-				  <version>2.12.1</version>
+				  <version>2.10.0</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>

--- a/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
+++ b/eclipse.platform.releng.prereqs.sdk/eclipse-sdk-prereqs.target
@@ -70,15 +70,15 @@
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
-      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.6.2.v20240812-1535"/>
-      <unit id="org.eclipse.ecf.core.feature.source.feature.group" version="1.6.2.v20240812-1535"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.14.1900.v20240812-1535"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.source.feature.group" version="3.14.1900.v20240812-1535"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="2.0.200.v20240808-1900"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.source.feature.group" version="2.0.200.v20240808-1900"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="1.1.702.v20240808-1900"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.source.feature.group" version="1.1.702.v20240808-1900"/>
-      <repository location="https://download.eclipse.org/rt/ecf/3.15.2/site.p2/3.15.2.v20240821-2119"/>
+      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.7.0.v20250111-0100"/>
+      <unit id="org.eclipse.ecf.core.feature.source.feature.group" version="1.7.0.v20250111-0100"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.15.0.v20250115-0406"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.source.feature.group" version="3.15.0.v20250115-0406"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="2.1.0.v20250108-1923"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.source.feature.group" version="2.1.0.v20250108-1923"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="1.2.0.v20250122-1953"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.source.feature.group" version="1.2.0.v20250122-1953"/>
+      <repository location="https://download.eclipse.org/rt/ecf/3.15.5/site.p2/3.15.5.v20250124-1843"/>
     </location>
 
     <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
@@ -96,7 +96,7 @@
 			  <dependency>
 				  <groupId>com.google.code.gson</groupId>
 				  <artifactId>gson</artifactId>
-				  <version>2.10.0</version>
+				  <version>2.12.1</version>
 				  <type>jar</type>
 			  </dependency>
 			  <dependency>


### PR DESCRIPTION
## The content of the target `eclipse-sdk-prereqs.target` was updated

Please review the changes and merge if appropriate, or cherry pick individual updates.

### The location https://download.eclipse.org/rt/ecf/3.15.2/site.p2/3.15.2.v20240821-2119 was updated:

- Location changed to https://download.eclipse.org/rt/ecf/3.15.5/site.p2/3.15.5.v20250124-1843
- Unit org.eclipse.ecf.core.feature.feature.group was updated from 1.6.2.v20240812-1535 to 1.7.0.v20250111-0100
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf [3.12.0.v20250111-0100,3.12.0.v20250111-0100] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.core.feature.feature.jar [1.7.0.v20250111-0100,1.7.0.v20250111-0100], filter=(org.eclipse.update.install.features=true) compared to the previous version
- Unit org.eclipse.ecf.core.feature.source.feature.group was updated from 1.6.2.v20240812-1535 to 1.7.0.v20250111-0100
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.source [3.12.0.v20250111-0100,3.12.0.v20250111-0100] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.core.feature.source.feature.jar [1.7.0.v20250111-0100,1.7.0.v20250111-0100], filter=(org.eclipse.update.install.features=true) compared to the previous version
- Unit org.eclipse.ecf.filetransfer.feature.feature.group was updated from 3.14.1900.v20240812-1535 to 3.15.0.v20250115-0406
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.provider.filetransfer [3.3.100.v20250115-0406,3.3.100.v20250115-0406] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.filetransfer.feature.feature.jar [3.15.0.v20250115-0406,3.15.0.v20250115-0406], filter=(org.eclipse.update.install.features=true) compared to the previous version
- Unit org.eclipse.ecf.filetransfer.feature.source.feature.group was updated from 3.14.1900.v20240812-1535 to 3.15.0.v20250115-0406
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.provider.filetransfer.source [3.3.100.v20250115-0406,3.3.100.v20250115-0406] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.filetransfer.feature.source.feature.jar [3.15.0.v20250115-0406,3.15.0.v20250115-0406], filter=(org.eclipse.update.install.features=true) compared to the previous version
- Unit org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group was updated from 2.0.200.v20240808-1900 to 2.1.0.v20250108-1923
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.provider.filetransfer.httpclientjava [2.1.0.v20250108-1923,2.1.0.v20250108-1923] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.jar [2.1.0.v20250108-1923,2.1.0.v20250108-1923], filter=(org.eclipse.update.install.features=true) compared to the previous version
- Unit org.eclipse.ecf.filetransfer.httpclientjava.feature.source.feature.group was updated from 2.0.200.v20240808-1900 to 2.1.0.v20250108-1923
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.provider.filetransfer.httpclientjava.source [2.1.0.v20250108-1923,2.1.0.v20250108-1923] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.filetransfer.httpclientjava.feature.source.feature.jar [2.1.0.v20250108-1923,2.1.0.v20250108-1923], filter=(org.eclipse.update.install.features=true) compared to the previous version
- Unit org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group was updated from 1.1.702.v20240808-1900 to 1.2.0.v20250122-1953
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.provider.filetransfer.httpclient5 [1.1.100.v20250108-1923,1.1.100.v20250108-1923] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.provider.filetransfer.httpclient5.win32 [1.1.200.v20250122-1953,1.1.200.v20250122-1953], filter=(osgi.os=win32) compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.apache.httpcomponents.client5.httpclient5 [5.4.1.v20241029-1100,5.4.1.v20241029-1100] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.apache.httpcomponents.core5.httpcore5 [5.3.2.v20250110-0800,5.3.2.v20250110-0800] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.apache.httpcomponents.core5.httpcore5-h2 [5.3.2.v20250110-0800,5.3.2.v20250110-0800] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.filetransfer.httpclient5.feature.feature.jar [1.2.0.v20250122-1953,1.2.0.v20250122-1953], filter=(org.eclipse.update.install.features=true) compared to the previous version
- Unit org.eclipse.ecf.filetransfer.httpclient5.feature.source.feature.group was updated from 1.1.702.v20240808-1900 to 1.2.0.v20250122-1953
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.provider.filetransfer.httpclient5.source [1.1.100.v20250108-1923,1.1.100.v20250108-1923] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.provider.filetransfer.httpclient5.win32.source [1.1.200.v20250122-1953,1.1.200.v20250122-1953], filter=(osgi.os=win32) compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.apache.httpcomponents.client5.httpclient5.source [5.4.1.v20241029-1100,5.4.1.v20241029-1100] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.apache.httpcomponents.core5.httpcore5.source [5.3.2.v20250110-0800,5.3.2.v20250110-0800] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.apache.httpcomponents.core5.httpcore5-h2.source [5.3.2.v20250110-0800,5.3.2.v20250110-0800] compared to the previous version
  - additionally requires org.eclipse.equinox.p2.iu; org.eclipse.ecf.filetransfer.httpclient5.feature.source.feature.jar [1.2.0.v20250122-1953,1.2.0.v20250122-1953], filter=(org.eclipse.update.install.features=true) compared to the previous version

### The following maven artifacts have been updated:

- `com.google.code.gson:gson:jar:2.10.0` has been updated to version `2.12.1`

